### PR TITLE
Hide the use of window.Vaadin.demoComponentsRoot

### DIFF
--- a/vaadin-demo-snippet.html
+++ b/vaadin-demo-snippet.html
@@ -272,6 +272,9 @@
         let snippet = this.$.marked.unindent(template.innerHTML)
           .replace(/window\.addDemoReadyListener\('[^{]+/g, `window.addEventListener('WebComponentsReady', function() `);
 
+        // Hide the use of window.Vaadin.demoComponentsRoot
+        snippet = snippet.replace(/`(\${window\.Vaadin\.demoComponentsRoot})(.+)`/gi, `'$2'`);
+
         // Remove style-scoped classes that are appended when ShadyDOM is enabled
         Array.from(this.classList).forEach(e => snippet = snippet.replace(new RegExp('\\s*' + e, 'g'), ''));
         snippet = snippet.replace(/ class=""/g, '');


### PR DESCRIPTION
This prevents us from confusing the users with internal stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vlukashov/vaadin-demo-helpers/6)
<!-- Reviewable:end -->
